### PR TITLE
fix typo in index

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -9,5 +9,5 @@ Contents
 
 .. toctree::
 
-   installation
+   install
    usage


### PR DESCRIPTION
"install" not "installation"